### PR TITLE
Add links to LinkedIn and Company website for MMW

### DIFF
--- a/docs/Contributors.md
+++ b/docs/Contributors.md
@@ -34,7 +34,7 @@ keywords:
 - Corey Samuels, Etsy
 - Kinga Kisielinska, Nobl9
 - Marco Torre, Accenture
-- Matthew Macdonald-Wallace, Contino
+- [Matthew Macdonald-Wallace](https://www.linkedin.com/in/mattmacdonald-wallace/), [Contino](https://www.contino.io)
 - Nader Mortazavi, Nobl9
 - Quan To, Nobl9
 - Rachel Head, Nobl9


### PR DESCRIPTION
Pretty much the title, updating the Contributors page to link to my LinkedIn Profile and our Company website.